### PR TITLE
Add shortcut capture modal for recording key combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # obsidian-shortcuts-recorder-plugin
-Records keyboard shortcuts into obsidian note to memorize them easily.
+Records keyboard shortcuts into Obsidian notes to memorise them easily.
+
+## Manual testing
+
+To validate the shortcut capture flow, exercise the plugin manually in Obsidian 1.5 or newer on:
+
+- macOS (for example, macOS Sonoma 14) – ensure Command/Option-based combinations render with platform-specific symbols such as `⌘`, `⌥`, and `⇧`.
+- Windows 11 or a modern Linux distribution – ensure Control/Alt-based combinations render in the `Ctrl +`/`Alt +` format.
+
+> **Limitations:** Operating systems and Obsidian reserve some global shortcuts (for example, `Cmd+Tab`, `Ctrl+Alt+Delete`, or `Cmd+Space`). These combinations cannot be intercepted by plugins, so they will not be recordable through the modal.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,21 @@
+import { Editor, Plugin } from "obsidian";
+import { ShortcutCaptureModal } from "./ui/ShortcutCaptureModal";
+
+export default class ShortcutsRecorderPlugin extends Plugin {
+  async onload(): Promise<void> {
+    this.addCommand({
+      id: "capture-shortcut",
+      name: "Capture shortcut",
+      editorCallback: (editor: Editor) => {
+        const modal = new ShortcutCaptureModal(this.app, {
+          editor,
+          onComplete: (shortcut) => {
+            console.debug("Captured shortcut", shortcut);
+          },
+        });
+
+        modal.open();
+      },
+    });
+  }
+}

--- a/src/ui/ShortcutCaptureModal.ts
+++ b/src/ui/ShortcutCaptureModal.ts
@@ -1,0 +1,258 @@
+import {
+  App,
+  ButtonComponent,
+  Editor,
+  EditorPosition,
+  Modal,
+  Setting,
+} from "obsidian";
+
+type CaptureResult = {
+  display: string;
+  key: string | null;
+};
+
+export interface ShortcutCaptureModalOptions {
+  editor: Editor;
+  onComplete?: (shortcut: string) => void;
+}
+
+const isMac = typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
+
+const MODIFIER_LABELS = isMac
+  ? {
+      Mod: "⌘",
+      Control: "⌃",
+      Alt: "⌥",
+      Shift: "⇧",
+    }
+  : {
+      Mod: "Ctrl",
+      Control: "Ctrl",
+      Alt: "Alt",
+      Shift: "Shift",
+    };
+
+const META_KEYS = new Set(["Meta", "OS"]);
+const CONTROL_KEYS = new Set(["Control", "Ctrl"]);
+const ALT_KEYS = new Set(["Alt", "Option"]);
+const SHIFT_KEYS = new Set(["Shift"]);
+
+const IGNORED_KEYS = new Set([
+  "Dead",
+  "Fn",
+  "Hyper",
+  "Super",
+]);
+
+const MODIFIER_KEYS = new Set([
+  ...META_KEYS,
+  ...CONTROL_KEYS,
+  ...ALT_KEYS,
+  ...SHIFT_KEYS,
+]);
+
+export class ShortcutCaptureModal extends Modal {
+  private readonly editor: Editor;
+  private readonly onComplete?: (shortcut: string) => void;
+
+  private captureEl!: HTMLDivElement;
+  private displayEl!: HTMLSpanElement;
+  private confirmButton?: ButtonComponent;
+  private currentShortcut: string | null = null;
+
+  constructor(app: App, options: ShortcutCaptureModalOptions) {
+    super(app);
+
+    this.editor = options.editor;
+    this.onComplete = options.onComplete;
+  }
+
+  onOpen(): void {
+    this.titleEl.setText("Capture shortcut");
+
+    this.contentEl.empty();
+    this.currentShortcut = null;
+
+    const description = this.contentEl.createEl("p", {
+      text: "Press the shortcut you want to record.",
+    });
+    description.addClass("shortcut-capture-description");
+
+    this.captureEl = this.contentEl.createDiv({
+      cls: "shortcut-capture-input",
+    });
+    this.captureEl.setAttr("tabindex", "0");
+    this.captureEl.setAttr("role", "button");
+    this.captureEl.setAttr("aria-label", "Shortcut capture field");
+
+    this.displayEl = this.captureEl.createEl("span", {
+      text: "Press keys…",
+    });
+
+    this.captureEl.addEventListener("keydown", this.handleKeyDown, {
+      passive: false,
+    });
+    this.captureEl.addEventListener("keyup", this.handleKeyUp, {
+      passive: false,
+    });
+
+    new Setting(this.contentEl)
+      .addButton((button) => {
+        button.setButtonText("Cancel").onClick(() => this.close());
+      })
+      .addButton((button) => {
+        this.confirmButton = button;
+        button
+          .setCta()
+          .setButtonText("Insert")
+          .setDisabled(true)
+          .onClick(() => this.commitShortcut());
+        this.updateConfirmState();
+      });
+
+    window.setTimeout(() => {
+      this.captureEl.focus({ preventScroll: true });
+    });
+  }
+
+  onClose(): void {
+    this.captureEl.removeEventListener("keydown", this.handleKeyDown);
+    this.captureEl.removeEventListener("keyup", this.handleKeyUp);
+    this.confirmButton?.setDisabled(true);
+    this.currentShortcut = null;
+    this.contentEl.empty();
+  }
+
+  private readonly handleKeyDown = (event: KeyboardEvent): void => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (event.repeat) {
+      return;
+    }
+
+    const result = this.buildShortcut(event);
+    if (!result.key) {
+      return;
+    }
+
+    this.currentShortcut = result.display;
+    this.displayEl.setText(result.display || "Press keys…");
+    this.updateConfirmState();
+  };
+
+  private readonly handleKeyUp = (event: KeyboardEvent): void => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  private buildShortcut(event: KeyboardEvent): CaptureResult {
+    const modifiers: string[] = [];
+
+    if (event.metaKey) {
+      modifiers.push(MODIFIER_LABELS.Mod);
+    }
+    if (event.ctrlKey) {
+      modifiers.push(MODIFIER_LABELS.Control);
+    }
+    if (event.altKey) {
+      modifiers.push(MODIFIER_LABELS.Alt);
+    }
+    if (event.shiftKey) {
+      modifiers.push(MODIFIER_LABELS.Shift);
+    }
+
+    const key = this.normalizeKey(event.key);
+    const displayParts = [...modifiers];
+    if (key) {
+      displayParts.push(key);
+    }
+
+    return {
+      display: displayParts.join(isMac ? "" : " + "),
+      key,
+    };
+  }
+
+  private normalizeKey(key: string): string | null {
+    if (!key || IGNORED_KEYS.has(key)) {
+      return null;
+    }
+
+    if (MODIFIER_KEYS.has(key)) {
+      return null;
+    }
+
+    if (key === " ") {
+      return "Space";
+    }
+
+    if (key.length === 1) {
+      return key.toUpperCase();
+    }
+
+    switch (key) {
+      case "ArrowUp":
+      case "ArrowDown":
+      case "ArrowLeft":
+      case "ArrowRight":
+        return key.replace("Arrow", "");
+      case "Escape":
+        return "Esc";
+      case "Backspace":
+        return "Backspace";
+      default:
+        return key;
+    }
+  }
+
+  private commitShortcut(): void {
+    if (!this.currentShortcut) {
+      return;
+    }
+
+    const { from, to } = this.getSelectionBounds();
+    this.editor.replaceRange(this.currentShortcut, from, to);
+
+    this.onComplete?.(this.currentShortcut);
+    this.close();
+  }
+
+  private getSelectionBounds(): { from: EditorPosition; to: EditorPosition } {
+    const selections = this.editor.listSelections();
+    if (selections.length > 0) {
+      const { anchor, head } = selections[0];
+      return this.normalizeRange(anchor, head);
+    }
+
+    const cursor = this.editor.getCursor();
+    return { from: cursor, to: cursor };
+  }
+
+  private normalizeRange(a: EditorPosition, b: EditorPosition): {
+    from: EditorPosition;
+    to: EditorPosition;
+  } {
+    if (a.line < b.line) {
+      return { from: a, to: b };
+    }
+    if (a.line > b.line) {
+      return { from: b, to: a };
+    }
+
+    if (a.ch <= b.ch) {
+      return { from: a, to: b };
+    }
+
+    return { from: b, to: a };
+  }
+
+  private updateConfirmState(): void {
+    if (this.confirmButton) {
+      this.confirmButton.setDisabled(!this.currentShortcut);
+    }
+  }
+}
+
+export default ShortcutCaptureModal;


### PR DESCRIPTION
## Summary
- add a modal that captures keyboard shortcuts with platform-aware modifier symbols
- wire the modal into the plugin command to insert formatted shortcuts into the active editor selection
- document manual testing expectations and OS-level shortcut limitations

## Testing
- not run (not applicable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d7bd938484832aa257aaabd292d8f2