### PR TITLE
Clarify installation instructions for packaged files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Record and manage keyboard shortcuts inside Obsidian.
 
 ## Installation
 
-1. Download the latest release or build the plugin following the development instructions below.
-2. Copy the following files into your Obsidian vault under `.obsidian/plugins/obsidian-shortcuts-recorder-plugin/`:
+1. Download `manifest.json` and `main.js` directly from this repository (for example, via the GitHub “Download raw file” option). Сompiling the project locally is **not required** for installing the plugin in Obsidian.
+2. Copy the downloaded files into your Obsidian vault under `.obsidian/plugins/obsidian-shortcuts-recorder-plugin/`:
    - `manifest.json`
    - `main.js`
-   - `styles.css` (if present)
+   - `styles.css` (если появится в будущих версиях)
 3. Reload Obsidian or enable the plugin from **Settings → Community plugins**.
 
 ## Development
@@ -17,11 +17,11 @@ Record and manage keyboard shortcuts inside Obsidian.
    ```bash
    npm install
    ```
-2. Build the plugin:
+2. (Необязательно) Соберите плагин локально:
    ```bash
    npm run build
    ```
-3. The compiled `main.js` will be generated in the repository root. Copy it along with `manifest.json` into your test vault's plugin directory to try out the plugin.
+   Учтите, что собранный таким образом `main.js` предназначен для разработки и может отличаться от опубликованной версии. Для установки в рабочий Obsidian используйте файлы из репозитория, как описано выше.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- update the installation section to tell users to copy `manifest.json` and `main.js` directly from the repository without building locally
- clarify that local builds are optional and meant for development, as their output may differ from the published plugin

## Testing
- not run (documentation change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7bce9d988832a96a2acf404a1ff94