### PR TITLE
Use shared shortcut capture modal in editor menu

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,29 +23,275 @@ __export(main_exports, {
   default: () => ShortcutRecorderPlugin
 });
 module.exports = __toCommonJS(main_exports);
+var import_obsidian2 = require("obsidian");
+
+// src/ui/ShortcutCaptureModal.ts
 var import_obsidian = require("obsidian");
-var ShortcutRecorderPlugin = class extends import_obsidian.Plugin {
-  constructor() {
-    super(...arguments);
-    this.statusBarItemEl = null;
-  }
-  async onload() {
-    console.log("Loading Shortcuts Recorder plugin");
-    this.statusBarItemEl = this.addStatusBarItem();
-    this.statusBarItemEl.setText("Shortcuts Recorder: Ready");
-    this.addCommand({
-      id: "shortcuts-recorder-show-status",
-      name: "Show recorder status",
-      callback: () => {
-        new import_obsidian.Notice("Shortcuts Recorder is ready to capture shortcuts.");
+var isMac = typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
+var MODIFIER_LABELS = isMac ? {
+  Mod: "\u2318",
+  Control: "\u2303",
+  Alt: "\u2325",
+  Shift: "\u21E7"
+} : {
+  Mod: "Ctrl",
+  Control: "Ctrl",
+  Alt: "Alt",
+  Shift: "Shift"
+};
+var META_KEYS = /* @__PURE__ */ new Set(["Meta", "OS"]);
+var CONTROL_KEYS = /* @__PURE__ */ new Set(["Control", "Ctrl"]);
+var ALT_KEYS = /* @__PURE__ */ new Set(["Alt", "Option"]);
+var SHIFT_KEYS = /* @__PURE__ */ new Set(["Shift"]);
+var IGNORED_KEYS = /* @__PURE__ */ new Set([
+  "Dead",
+  "Fn",
+  "Hyper",
+  "Super"
+]);
+var MODIFIER_KEYS = /* @__PURE__ */ new Set([
+  ...META_KEYS,
+  ...CONTROL_KEYS,
+  ...ALT_KEYS,
+  ...SHIFT_KEYS
+]);
+var ShortcutCaptureModal = class extends import_obsidian.Modal {
+  constructor(app, options) {
+    super(app);
+    this.currentShortcut = null;
+    this.handleKeyDown = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.repeat) {
+        return;
       }
+      const result = this.buildShortcut(event);
+      if (!result.key) {
+        return;
+      }
+      this.currentShortcut = result.display;
+      this.displayEl.setText(result.display || "Press keys\u2026");
+      this.updateConfirmState();
+    };
+    this.handleKeyUp = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    this.editor = options.editor;
+    this.onComplete = options.onComplete;
+  }
+  onOpen() {
+    this.titleEl.setText("Capture shortcut");
+    this.contentEl.empty();
+    this.currentShortcut = null;
+    const description = this.contentEl.createEl("p", {
+      text: "Press the shortcut you want to record."
+    });
+    description.addClass("shortcut-capture-description");
+    this.captureEl = this.contentEl.createDiv({
+      cls: "shortcut-capture-input"
+    });
+    this.captureEl.setAttr("tabindex", "0");
+    this.captureEl.setAttr("role", "button");
+    this.captureEl.setAttr("aria-label", "Shortcut capture field");
+    this.displayEl = this.captureEl.createEl("span", {
+      text: "Press keys\u2026"
+    });
+    this.captureEl.addEventListener("keydown", this.handleKeyDown, {
+      passive: false
+    });
+    this.captureEl.addEventListener("keyup", this.handleKeyUp, {
+      passive: false
+    });
+    new import_obsidian.Setting(this.contentEl).addButton((button) => {
+      button.setButtonText("Cancel").onClick(() => this.close());
+    }).addButton((button) => {
+      this.confirmButton = button;
+      button.setCta().setButtonText("Insert").setDisabled(true).onClick(() => this.commitShortcut());
+      this.updateConfirmState();
+    });
+    window.setTimeout(() => {
+      this.captureEl.focus({ preventScroll: true });
     });
   }
-  onunload() {
-    console.log("Unloading Shortcuts Recorder plugin");
-    if (this.statusBarItemEl) {
-      this.statusBarItemEl.remove();
-      this.statusBarItemEl = null;
+  onClose() {
+    var _a;
+    this.captureEl.removeEventListener("keydown", this.handleKeyDown);
+    this.captureEl.removeEventListener("keyup", this.handleKeyUp);
+    (_a = this.confirmButton) == null ? void 0 : _a.setDisabled(true);
+    this.currentShortcut = null;
+    this.contentEl.empty();
+  }
+  buildShortcut(event) {
+    const modifiers = [];
+    if (event.metaKey) {
+      modifiers.push(MODIFIER_LABELS.Mod);
     }
+    if (event.ctrlKey) {
+      modifiers.push(MODIFIER_LABELS.Control);
+    }
+    if (event.altKey) {
+      modifiers.push(MODIFIER_LABELS.Alt);
+    }
+    if (event.shiftKey) {
+      modifiers.push(MODIFIER_LABELS.Shift);
+    }
+    const key = this.normalizeKey(event.key);
+    const displayParts = [...modifiers];
+    if (key) {
+      displayParts.push(key);
+    }
+    return {
+      display: displayParts.join(isMac ? "" : " + "),
+      key
+    };
+  }
+  normalizeKey(key) {
+    if (!key || IGNORED_KEYS.has(key)) {
+      return null;
+    }
+    if (MODIFIER_KEYS.has(key)) {
+      return null;
+    }
+    if (key === " ") {
+      return "Space";
+    }
+    if (key.length === 1) {
+      return key.toUpperCase();
+    }
+    switch (key) {
+      case "ArrowUp":
+      case "ArrowDown":
+      case "ArrowLeft":
+      case "ArrowRight":
+        return key.replace("Arrow", "");
+      case "Escape":
+        return "Esc";
+      case "Backspace":
+        return "Backspace";
+      default:
+        return key;
+    }
+  }
+  commitShortcut() {
+    var _a;
+    if (!this.currentShortcut) {
+      return;
+    }
+    const { from, to } = this.getSelectionBounds();
+    this.editor.replaceRange(this.currentShortcut, from, to);
+    (_a = this.onComplete) == null ? void 0 : _a.call(this, this.currentShortcut);
+    this.close();
+  }
+  getSelectionBounds() {
+    const selections = this.editor.listSelections();
+    if (selections.length > 0) {
+      const { anchor, head } = selections[0];
+      return this.normalizeRange(anchor, head);
+    }
+    const cursor = this.editor.getCursor();
+    return { from: cursor, to: cursor };
+  }
+  normalizeRange(a, b) {
+    if (a.line < b.line) {
+      return { from: a, to: b };
+    }
+    if (a.line > b.line) {
+      return { from: b, to: a };
+    }
+    if (a.ch <= b.ch) {
+      return { from: a, to: b };
+    }
+    return { from: b, to: a };
+  }
+  updateConfirmState() {
+    if (this.confirmButton) {
+      this.confirmButton.setDisabled(!this.currentShortcut);
+    }
+  }
+};
+var ShortcutCaptureModal_default = ShortcutCaptureModal;
+
+// src/services/ShortcutCaptureService.ts
+var ShortcutCaptureService = class {
+  constructor(app) {
+    this.app = app;
+  }
+  openCaptureModal(editor, onComplete) {
+    new ShortcutCaptureModal_default(this.app, { editor, onComplete }).open();
+  }
+};
+
+// src/main.ts
+var ShortcutRecorderPlugin = class extends import_obsidian2.Plugin {
+  async onload() {
+    this.captureService = new ShortcutCaptureService(this.app);
+    this.registerEvent(
+      this.app.workspace.on("editor-menu", (menu, editor, view) => {
+        if (!(view instanceof import_obsidian2.MarkdownView)) {
+          return;
+        }
+        const mode = view.getMode();
+        if (mode !== "source" && mode !== "live") {
+          return;
+        }
+        const cursor = editor.getCursor();
+        if (!cursor) {
+          return;
+        }
+        if (!this.isCursorInMarkdownTable(editor, cursor)) {
+          return;
+        }
+        menu.addItem((item) => {
+          item.setTitle("Record keyboard shortcut").setIcon("keyboard").onClick(() => {
+            this.captureService.openCaptureModal(editor);
+          });
+        });
+      })
+    );
+  }
+  isCursorInMarkdownTable(editor, cursor) {
+    var _a, _b, _c;
+    const lineText = (_a = editor.getLine(cursor.line)) != null ? _a : "";
+    if (!this.lineLooksLikeTable(lineText)) {
+      return false;
+    }
+    const beforeCursor = lineText.slice(0, cursor.ch);
+    const afterCursor = lineText.slice(cursor.ch);
+    if (!beforeCursor.includes("|") || !afterCursor.includes("|")) {
+      return false;
+    }
+    if (this.isDividerRow(lineText)) {
+      return true;
+    }
+    const prevLine = cursor.line > 0 ? (_b = editor.getLine(cursor.line - 1)) != null ? _b : "" : "";
+    const nextLine = (_c = editor.getLine(cursor.line + 1)) != null ? _c : "";
+    if (this.isDividerRow(prevLine) || this.isDividerRow(nextLine)) {
+      return true;
+    }
+    if (this.lineLooksLikeTable(prevLine) || this.lineLooksLikeTable(nextLine)) {
+      return true;
+    }
+    return false;
+  }
+  lineLooksLikeTable(line) {
+    if (!line) {
+      return false;
+    }
+    const trimmed = line.trim();
+    if (!trimmed.includes("|")) {
+      return false;
+    }
+    if (/^```/.test(trimmed) || /^---/.test(trimmed)) {
+      return false;
+    }
+    return true;
+  }
+  isDividerRow(line) {
+    if (!line) {
+      return false;
+    }
+    const trimmed = line.trim();
+    return /^\|?(\s*:?-+:?\s*\|)+\s*$/.test(trimmed);
   }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,7 @@ export default class ShortcutRecorderPlugin extends Plugin {
             .setTitle('Record keyboard shortcut')
             .setIcon('keyboard')
             .onClick(() => {
-              this.captureService.openCaptureModal();
+              this.captureService.openCaptureModal(editor);
             });
         });
       })

--- a/src/services/ShortcutCaptureService.ts
+++ b/src/services/ShortcutCaptureService.ts
@@ -1,24 +1,13 @@
-import { App, Modal } from 'obsidian';
+import { App, Editor } from 'obsidian';
+import ShortcutCaptureModal from '../ui/ShortcutCaptureModal';
 
 export class ShortcutCaptureService {
   constructor(private readonly app: App) {}
 
-  openCaptureModal(): void {
-    new ShortcutCaptureModal(this.app).open();
-  }
-}
-
-class ShortcutCaptureModal extends Modal {
-  onOpen(): void {
-    const { contentEl } = this;
-    contentEl.empty();
-    contentEl.createEl('h2', { text: 'Record keyboard shortcut' });
-    contentEl.createEl('p', {
-      text: 'Press the desired keyboard shortcut to record it.',
-    });
-  }
-
-  onClose(): void {
-    this.contentEl.empty();
+  openCaptureModal(
+    editor: Editor,
+    onComplete?: (shortcut: string) => void
+  ): void {
+    new ShortcutCaptureModal(this.app, { editor, onComplete }).open();
   }
 }


### PR DESCRIPTION
## Summary
- replace the stub capture modal in the shortcut capture service with the shared UI modal
- pass the active editor to the capture modal when invoked from the editor menu
- rebuild the plugin bundle so main.js reflects the updated TypeScript sources

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7d0c90de0832a96ace5b7d6981045