### PR TITLE
Enable shortcut capture after percent symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Record and manage keyboard shortcuts inside Obsidian.
 
+## Usage
+
+- Place the cursor immediately after a `%` character in any Markdown file to reveal the **Record keyboard shortcut** command from the editor menu. This works even outside Markdown tables.
+
 ## Installation
 
 1. Download `manifest.json` and `main.js` directly from this repository (for example, via the GitHub “Download raw file” option). Сompiling the project locally is **not required** for installing the plugin in Obsidian.

--- a/main.js
+++ b/main.js
@@ -239,7 +239,8 @@ var ShortcutRecorderPlugin = class extends import_obsidian2.Plugin {
         if (!cursor) {
           return;
         }
-        if (!this.isCursorInMarkdownTable(editor, cursor)) {
+        const isAfterPercent = this.isCursorAfterPercent(editor, cursor);
+        if (!isAfterPercent && !this.isCursorInMarkdownTable(editor, cursor)) {
           return;
         }
         menu.addItem((item) => {
@@ -293,5 +294,16 @@ var ShortcutRecorderPlugin = class extends import_obsidian2.Plugin {
     }
     const trimmed = line.trim();
     return /^\|?(\s*:?-+:?\s*\|)+\s*$/.test(trimmed);
+  }
+  isCursorAfterPercent(editor, cursor) {
+    var _a;
+    if (cursor.ch <= 0) {
+      return false;
+    }
+    const lineText = (_a = editor.getLine(cursor.line)) != null ? _a : "";
+    if (!lineText) {
+      return false;
+    }
+    return lineText.charAt(cursor.ch - 1) === "%";
   }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,9 @@ export default class ShortcutRecorderPlugin extends Plugin {
           return;
         }
 
-        if (!this.isCursorInMarkdownTable(editor, cursor)) {
+        const isAfterPercent = this.isCursorAfterPercent(editor, cursor);
+
+        if (!isAfterPercent && !this.isCursorInMarkdownTable(editor, cursor)) {
           return;
         }
 
@@ -99,5 +101,18 @@ export default class ShortcutRecorderPlugin extends Plugin {
 
     const trimmed = line.trim();
     return /^\|?(\s*:?-+:?\s*\|)+\s*$/.test(trimmed);
+  }
+
+  private isCursorAfterPercent(editor: Editor, cursor: EditorPosition): boolean {
+    if (cursor.ch <= 0) {
+      return false;
+    }
+
+    const lineText = editor.getLine(cursor.line) ?? '';
+    if (!lineText) {
+      return false;
+    }
+
+    return lineText.charAt(cursor.ch - 1) === '%';
   }
 }


### PR DESCRIPTION
## Summary
- allow the shortcut recording command to appear when the cursor is directly after a percent sign
- keep the table detection fallback and expose the percent check as a dedicated helper
- document the new cursor-after-percent usage scenario in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7d80b5798832aaaedfb6f218cb258